### PR TITLE
Don't use xargs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           New-Item -Path ${{ github.workspace }}/root/child/grandchild/ignored.txt -ItemType "file"
 
       - name: Build and run google/bloaty
-        uses: thebrowsercompany/gha-google-bloaty@main
+        uses: thebrowsercompany/gha-google-bloaty@kendal/dont-use-xargs
         with:
           bloaty-version: ${{ env.BLOATY_VERSION }}
           bloaty-args: -d inputfiles,segments

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           New-Item -Path ${{ github.workspace }}/root/child/grandchild/ignored.txt -ItemType "file"
 
       - name: Build and run google/bloaty
-        uses: thebrowsercompany/gha-google-bloaty@kendal/dont-use-xargs
+        uses: thebrowsercompany/gha-google-bloaty@main
         with:
           bloaty-version: ${{ env.BLOATY_VERSION }}
           bloaty-args: -d inputfiles,segments

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,10 @@ runs:
           # Glob files and generate filenames in the options file, replacing backslashes
           # with forward slashes.
           for Pattern in ${Patterns[@]}; do
-            ls "${Pattern}" | xargs -I {} echo "filename: \"{}\"" >> $BLOATY_OPTIONS_FILE
+            # We don't use xargs here because it can't handle large inputs.
+            for Filename in $(ls "${Pattern}"); do
+              echo "filename: \"${Filename}\"" >> $BLOATY_OPTIONS_FILE
+            done
           done
 
           echo "-- Contents of $BLOATY_OPTIONS_FILE"


### PR DESCRIPTION
xargs can't handle long inputs (common when using bloaty to analyze dlls from the swift toolchain build)

Instead just use a for-loop to iterate over the files matched by the caller's glob pattern.

Tested using the swift-toolchain:
- Before this change: https://github.com/thebrowsercompany/swift-build/actions/runs/8835618641
- After this change: https://github.com/thebrowsercompany/swift-build/actions/runs/8835898493